### PR TITLE
ローカルでも github actions と同じバージョニングルールを採用. その他微修正

### DIFF
--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -40,13 +40,14 @@ jobs:
           REF: ${{ github.ref }}
           COMMIT: ${{ github.sha }}
         run: |
+          code_name="$(lsb_release -cs)"
           cp "scripts/changelog_template" "nginx/debian/changelog"
           sed -i -r "s/%DATE%/$(LC_ALL=C TZ=JST-9 date '+%a, %d %b %Y %H:%M:%S %z')/g" nginx/debian/changelog
           if [ "${REF:0:11}" = "refs/tags/v" ]; then
-            sed -i -r "s/X.Y.Z-alpha/${REF:11}.$(TZ=JST-9 date +%Y%m%d)/g" nginx/debian/changelog
+            sed -i -r "s/X.Y.Z-alpha/${REF:11}.$(TZ=JST-9 date +%Y%m%d)+${code_name}/g" nginx/debian/changelog
           else
             nginx_src_dir=$(basename "$(ls -1vd nginx/nginx-*.tar.gz | tail -n 1)" .tar.gz)
-            sed -i -r "s/X.Y.Z-alpha/${nginx_src_dir:6}-$(TZ=JST-9 date +%Y%m%d.%H%M%S).${COMMIT:0:7}/g" nginx/debian/changelog
+            sed -i -r "s/X.Y.Z-alpha/${nginx_src_dir:6}-$(TZ=JST-9 date +%Y%m%d.%H%M%S).${COMMIT:0:7}+${code_name}/g" nginx/debian/changelog
           fi
           bash scripts/build.sh
 

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -12,7 +12,7 @@ on:
       - master
 
 jobs:
-  build:
+  build_for_bionic:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -63,9 +63,9 @@ jobs:
           name: nginx
           path: nginx/${{ steps.get_deb_name.outputs.filename }}
 
-  release:
+  release_for_bionic:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: build
+    needs: build_for_bionic
     runs-on: ubuntu-18.04
     steps:
       - name: Download artifact

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Upload result
         uses: actions/upload-artifact@v1
         with:
-          name: nginx
+          name: nginx_bionic
           path: nginx/${{ steps.get_deb_name.outputs.filename }}
 
   release_for_bionic:
@@ -71,12 +71,12 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v1
         with:
-          name: nginx
+          name: nginx_bionic
 
       - name: Get debian package name
         shell: bash
         run: |
-          echo "::set-output name=filename::$(basename $(find ./nginx -type f -name \*.deb))"
+          echo "::set-output name=filename::$(basename $(find ./nginx_bionic -type f -name \*.deb))"
         id: get_deb_name
 
       - name: Create release
@@ -97,6 +97,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: nginx/${{ steps.get_deb_name.outputs.filename }}
+          asset_path: nginx_bionic/${{ steps.get_deb_name.outputs.filename }}
           asset_name: ${{ steps.get_deb_name.outputs.filename }}
           asset_content_type: application/vnd.debian.binary-package

--- a/scripts/changelog_template
+++ b/scripts/changelog_template
@@ -1,5 +1,5 @@
 nginx (X.Y.Z-alpha) unstable; urgency=medium
 
-  * Update package
+  * See https://github.com/link-u/dpkg_nginx/releases
 
  -- Yoshimasa Hashida <yoshimasa.hashida@link-u.co.jp> %DATE%

--- a/scripts/create_changelog.sh
+++ b/scripts/create_changelog.sh
@@ -9,13 +9,16 @@ root_dir=$(env --chdir "$(dirname $0)/.." pwd)
 git_commit="$(git rev-parse HEAD)"
 git_ref="$(git tag --points-at ${git_commit})"
 
+## ディストリビューションのコードネームの取得
+code_name="$(lsb_release -cs)"
+
 ## changelog の作成
 cp "${root_dir}/scripts/changelog_template" "${root_dir}/nginx/debian/changelog"
 env --chdir "${root_dir}/nginx/debian" sed -i -r "s/%DATE%/$(LC_ALL=C TZ=JST-9 date '+%a, %d %b %Y %H:%M:%S %z')/g" changelog
 if [ "${git_ref:0:1}" = "v" ]; then
-  env --chdir "${root_dir}/nginx/debian" sed -i -r "s/X.Y.Z-alpha/${git_ref:1}.$(TZ=JST-9 date +%Y%m%d)/g" changelog
+  env --chdir "${root_dir}/nginx/debian" sed -i -r "s/X.Y.Z-alpha/${git_ref:1}.$(TZ=JST-9 date +%Y%m%d)+${code_name}/g" changelog
 else
   ## nginx のソースディレクトリ名の取得 (バージョン名の取得のため)
   nginx_src_dir=$(basename "$(ls -1vd ${root_dir}/nginx/nginx-*.tar.gz | tail -n 1)" .tar.gz);
-  env --chdir "${root_dir}/nginx/debian" sed -i -r "s/X.Y.Z-alpha/${nginx_src_dir:6}-$(TZ=JST-9 date +%Y%m%d.%H%M%S).${git_commit:0:7}/g" changelog
+  env --chdir "${root_dir}/nginx/debian" sed -i -r "s/X.Y.Z-alpha/${nginx_src_dir:6}-$(TZ=JST-9 date +%Y%m%d.%H%M%S).${git_commit:0:7}+${code_name}/g" changelog
 fi

--- a/scripts/create_changelog.sh
+++ b/scripts/create_changelog.sh
@@ -5,10 +5,17 @@ set -eu
 ## git リポジトリ上の root のパスを取得
 root_dir=$(env --chdir "$(dirname $0)/.." pwd)
 
-## nginx のソースディレクトリ名の取得 (バージョン名の取得のため)
-nginx_src_dir=$(basename "$(ls -1vd ${root_dir}/nginx/nginx-*.tar.gz | tail -n 1)" .tar.gz);
+## HEAD のコミットID と HEAD の時のタグを取得
+git_commit="$(git rev-parse HEAD)"
+git_ref="$(git tag --points-at ${git_commit})"
 
 ## changelog の作成
 cp "${root_dir}/scripts/changelog_template" "${root_dir}/nginx/debian/changelog"
-env --chdir "${root_dir}/nginx/debian" sed -i -r "s/X.Y.Z/${nginx_src_dir:6}/g" changelog
-env --chdir "${root_dir}/nginx/debian" sed -i "s/%DATE%/$(LC_ALL=C TZ=JST-9 date '+%a, %d %b %Y %H:%M:%S %z')/g" changelog
+env --chdir "${root_dir}/nginx/debian" sed -i -r "s/%DATE%/$(LC_ALL=C TZ=JST-9 date '+%a, %d %b %Y %H:%M:%S %z')/g" changelog
+if [ "${git_ref:0:1}" = "v" ]; then
+  env --chdir "${root_dir}/nginx/debian" sed -i -r "s/X.Y.Z-alpha/${git_ref:1}.$(TZ=JST-9 date +%Y%m%d)/g" changelog
+else
+  ## nginx のソースディレクトリ名の取得 (バージョン名の取得のため)
+  nginx_src_dir=$(basename "$(ls -1vd ${root_dir}/nginx/nginx-*.tar.gz | tail -n 1)" .tar.gz);
+  env --chdir "${root_dir}/nginx/debian" sed -i -r "s/X.Y.Z-alpha/${nginx_src_dir:6}-$(TZ=JST-9 date +%Y%m%d.%H%M%S).${git_commit:0:7}/g" changelog
+fi


### PR DESCRIPTION
### 変更点
* bash scripts/all.sh でも github actions でも同じルールでバージョニングされたビルドができるようにした.
* パッケージ名に OS のコードネーム `$(lsb_release -cs)` を付け足す. (まだできていない)
  ```
  ## ubuntu 18.04
  $ lsb_release -cs
  bionic

  ## ubuntu 20.04
  $ lsb_release -cs
  focal
  ```

* changelog に release note の URL を記載.