### PR TITLE
Add vts module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "nginx-rtmp-module"]
 	path = nginx-rtmp-module
 	url = git@github.com:arut/nginx-rtmp-module.git
+[submodule "nginx-module-vts"]
+	path = nginx-module-vts
+	url = git://github.com/vozlt/nginx-module-vts.git

--- a/nginx/_configure.sh
+++ b/nginx/_configure.sh
@@ -54,5 +54,6 @@ ld_opt="-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -Wl,--as-needed"
 --with-zlib="../../zlib/zlib-1.2.11" \
 --add-module=../../ngx_brotli \
 --add-module=../../nginx-rtmp-module \
+--add-module=../../nginx-module-vts \
 --with-cc-opt="${cc_opt}" \
 --with-ld-opt="${ld_opt}"


### PR DESCRIPTION
It's because we would like to use [nginx-module-vts](https://github.com/vozlt/nginx-module-vts) to monitor nginx in more detail!